### PR TITLE
Switched to array_split

### DIFF
--- a/pano-split.py
+++ b/pano-split.py
@@ -11,6 +11,6 @@ pano = cv2.imread(sys.argv[1])
 pano_height, pano_width, _ = pano.shape
 num_splits = int(sys.argv[2])
 split_width = int(pano_width/num_splits)
-splits = np.split(pano,3,1)
+splits = np.array_split(pano,3,1)
 for i in range(num_splits):
     cv2.imwrite('split_%d.jpg'%i, splits[i])


### PR DESCRIPTION
regular np.split would raise an exception if the width couldn't be evenly divided by the number of splits wanted